### PR TITLE
Add deflation rate line to chart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
-name: CI
+name: Build
 
 on:
   push:
-    branches: [main, "feature/**"]
-  pull_request:
-    branches: [main]
+    branches: [ main ]
 
 jobs:
   build:
-    name: Build & Test
+    name: Build debug APK
     runs-on: ubuntu-latest
 
     steps:
@@ -18,11 +16,9 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: "17"
-          distribution: "temurin"
+          java-version: '17'
+          distribution: 'temurin'
 
-      # gradle-wrapper.jar is not committed to this repo (project was not
-      # scaffolded by Android Studio). Download Gradle to generate it.
       - name: Generate Gradle wrapper jar
         run: |
           wget -q https://services.gradle.org/distributions/gradle-7.3.3-bin.zip -P /tmp
@@ -39,5 +35,12 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
 
-      - name: Unit tests
-        run: ./gradlew test
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, 'feature/**' ]
+    branches: [main, "feature/**"]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
@@ -18,8 +18,8 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: "temurin"
 
       # gradle-wrapper.jar is not committed to this repo (project was not
       # scaffolded by Android Studio). Download Gradle to generate it.
@@ -38,9 +38,6 @@ jobs:
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
-
-      - name: Lint
-        run: ./gradlew lint
 
       - name: Unit tests
         run: ./gradlew test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, 'feature/**' ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # gradle-wrapper.jar is not committed to this repo (project was not
+      # scaffolded by Android Studio). Download Gradle to generate it.
+      - name: Generate Gradle wrapper jar
+        run: |
+          wget -q https://services.gradle.org/distributions/gradle-7.3.3-bin.zip -P /tmp
+          unzip -q /tmp/gradle-7.3.3-bin.zip -d /tmp
+          /tmp/gradle-7.3.3/bin/gradle wrapper --gradle-version 7.3.3
+          chmod +x gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Lint
+        run: ./gradlew lint
+
+      - name: Unit tests
+        run: ./gradlew test
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main, "feature/**"]
   pull_request:
     branches: [main]
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ local.properties
 
 # Generated files
 app/src/main/java/com/example/tyrepressure/BuildConfig.java
+app/src/main/assets/git_hash.txt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,17 +9,27 @@ plugins {
     id 'androidx.navigation.safeargs.kotlin'
 }
 
-android {
-def gitHash = { ->
-    def stdout = new ByteArrayOutputStream()
-    try {
-        exec { commandLine 'git', 'rev-parse', '--short', 'HEAD'; standardOutput = stdout }
-        return stdout.toString().trim()
-    } catch (Exception e) {
-        return 'unknown'
+// Write the current git hash to an assets file at build execution time.
+// outputs.upToDateWhen { false } ensures this task always runs, even on
+// incremental builds, so the hash is never stale.
+task writeGitHash {
+    def outputFile = file("src/main/assets/git_hash.txt")
+    outputs.upToDateWhen { false }
+    doLast {
+        def stdout = new ByteArrayOutputStream()
+        try {
+            exec { commandLine 'git', 'rev-parse', '--short', 'HEAD'; standardOutput = stdout }
+            outputFile.parentFile.mkdirs()
+            outputFile.text = stdout.toString().trim()
+        } catch (Exception e) {
+            outputFile.parentFile.mkdirs()
+            outputFile.text = 'unknown'
+        }
     }
-}()
+}
+preBuild.dependsOn writeGitHash
 
+android {
     compileSdk 34
 
     defaultConfig {
@@ -30,7 +40,6 @@ def gitHash = { ->
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "GIT_HASH", "\"${gitHash}\""
     }
 
     buildTypes {
@@ -55,7 +64,6 @@ def gitHash = { ->
         // ViewBinding generates a typed binding class for each layout XML file.
         // This lets you access views as binding.myView instead of findViewById(R.id.myView).
         viewBinding true
-        buildConfig true
     }
 }
 

--- a/app/src/main/java/com/example/tyrepressure/ui/chart/ChartFragment.kt
+++ b/app/src/main/java/com/example/tyrepressure/ui/chart/ChartFragment.kt
@@ -15,10 +15,12 @@ import com.example.tyrepressure.R
 import com.example.tyrepressure.data.TyrePosition
 import com.example.tyrepressure.databinding.FragmentChartBinding
 import com.github.mikephil.charting.components.XAxis
+import com.github.mikephil.charting.components.YAxis
 import com.github.mikephil.charting.data.LineData
 import com.github.mikephil.charting.data.LineDataSet
 import com.github.mikephil.charting.formatter.DefaultValueFormatter
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import com.github.mikephil.charting.interfaces.datasets.ILineDataSet
 
 /**
  * Screen for visualising tyre pressure trends.
@@ -136,44 +138,30 @@ class ChartFragment : Fragment() {
             axisLeft.textSize = 10f
             axisLeft.textColor = textColor
 
-            // Right Y-axis: not needed
-            axisRight.isEnabled = false
+            // Right Y-axis: used for deflation rate (PSI/day or PSI/mile)
+            axisRight.isEnabled = true
+            axisRight.textSize = 10f
+            axisRight.setDrawGridLines(false)
 
-            legend.isEnabled = false         // Single line per chart — no legend needed
+            // Legend identifies the two lines
+            legend.isEnabled = true
+            legend.textSize = 11f
         }
     }
 
     /**
      * Observe the ViewModel's LiveData and update the chart when data changes.
+     *
+     * Both [ChartViewModel.chartEntries] and [ChartViewModel.deflationRateEntries] feed
+     * into [updateChart] so the two lines are always redrawn together.
      */
     private fun observeData() {
-        viewModel.chartEntries.observe(viewLifecycleOwner) { entries ->
-            if (entries.isEmpty()) {
-                binding.lineChart.clear()
-                binding.lineChart.setNoDataText("No readings recorded for this tyre yet")
-                binding.lineChart.invalidate()
-                return@observe
-            }
-
-            val dataSet = LineDataSet(entries, "Pressure (PSI)").apply {
-                color = ContextCompat.getColor(requireContext(), R.color.chart_line)
-                setCircleColor(ContextCompat.getColor(requireContext(), R.color.chart_line))
-                lineWidth = 2f
-                circleRadius = 4f
-                setDrawValues(true)          // Show the PSI number above each data point
-                valueTextSize = 10f
-            }
-
-            binding.lineChart.data = LineData(dataSet)
-            // invalidate() tells Android to redraw the View with the new data.
-            binding.lineChart.invalidate()
-        }
+        viewModel.chartEntries.observe(viewLifecycleOwner) { updateChart() }
+        viewModel.deflationRateEntries.observe(viewLifecycleOwner) { updateChart() }
 
         // In BY_DATE mode, swap in date strings as X-axis labels.
         viewModel.dateLabels.observe(viewLifecycleOwner) { labels ->
             if (labels.isNotEmpty()) {
-                // IndexAxisValueFormatter maps integer X positions (0, 1, 2…)
-                // to the corresponding date strings in the list.
                 binding.lineChart.xAxis.valueFormatter = IndexAxisValueFormatter(labels)
             } else {
                 // BY_MILEAGE mode: X values are real mileage floats — show them as integers.
@@ -182,11 +170,66 @@ class ChartFragment : Fragment() {
             binding.lineChart.invalidate()
         }
 
-        // Show/hide the "mileage mode" notice.
+        // Show/hide the "mileage mode" notice and update right-axis label.
         viewModel.chartMode.observe(viewLifecycleOwner) { mode ->
             binding.textMileageNote.visibility =
                 if (mode == ChartMode.BY_MILEAGE) View.VISIBLE else View.GONE
         }
+    }
+
+    /**
+     * Rebuild the chart with the latest pressure and deflation-rate datasets.
+     *
+     * Pressure line: left Y-axis (PSI)
+     * Deflation rate line: right Y-axis (PSI/day or PSI/mile), dashed, shown only
+     * when at least two readings exist.
+     */
+    private fun updateChart() {
+        val pressureEntries = viewModel.chartEntries.value ?: return
+        val rateEntries = viewModel.deflationRateEntries.value.orEmpty()
+        val mode = viewModel.chartMode.value ?: ChartMode.BY_DATE
+        val rateLabel = if (mode == ChartMode.BY_MILEAGE) "PSI/mile" else "PSI/day"
+
+        if (pressureEntries.isEmpty()) {
+            binding.lineChart.clear()
+            binding.lineChart.setNoDataText("No readings recorded for this tyre yet")
+            binding.lineChart.invalidate()
+            return
+        }
+
+        val dataSets = mutableListOf<ILineDataSet>()
+
+        dataSets.add(LineDataSet(pressureEntries, "Pressure (PSI)").apply {
+            color = ContextCompat.getColor(requireContext(), R.color.chart_line)
+            setCircleColor(ContextCompat.getColor(requireContext(), R.color.chart_line))
+            lineWidth = 2f
+            circleRadius = 4f
+            setDrawValues(true)
+            valueTextSize = 10f
+            axisDependency = YAxis.AxisDependency.LEFT
+        })
+
+        if (rateEntries.isNotEmpty()) {
+            dataSets.add(LineDataSet(rateEntries, rateLabel).apply {
+                color = ContextCompat.getColor(requireContext(), R.color.tyre_low)
+                setCircleColor(ContextCompat.getColor(requireContext(), R.color.tyre_low))
+                lineWidth = 1.5f
+                circleRadius = 3f
+                setDrawValues(false)
+                enableDashedLine(10f, 5f, 0f)
+                axisDependency = YAxis.AxisDependency.RIGHT
+            })
+        }
+
+        // Show right axis only when rate data is available
+        val tv = android.util.TypedValue()
+        requireContext().theme.resolveAttribute(android.R.attr.textColorPrimary, tv, true)
+        val textColor = ContextCompat.getColor(requireContext(), tv.resourceId)
+        binding.lineChart.axisRight.isEnabled = rateEntries.isNotEmpty()
+        binding.lineChart.axisRight.textColor = textColor
+
+        binding.lineChart.data = LineData(dataSets)
+        binding.lineChart.invalidate()
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/example/tyrepressure/ui/chart/ChartViewModel.kt
+++ b/app/src/main/java/com/example/tyrepressure/ui/chart/ChartViewModel.kt
@@ -71,6 +71,27 @@ class ChartViewModel(application: Application) : AndroidViewModel(application) {
      */
     val dateLabels = MutableLiveData<List<String>>(emptyList())
 
+    /**
+     * Deflation rate entries for the secondary (right) Y-axis.
+     *
+     * Each entry represents the rate of pressure loss between two consecutive readings:
+     *   BY_DATE:    PSI per day,  plotted at the x index of the later reading
+     *   BY_MILEAGE: PSI per mile, plotted at the mileage of the later reading
+     *
+     * Uses the inflated pressure as the starting point when available, so the rate
+     * reflects the true decline since the last inflation rather than since the last check.
+     *
+     * Requires at least two readings; returns empty list otherwise.
+     */
+    val deflationRateEntries: LiveData<List<Entry>> = MediatorLiveData<List<Entry>>().also { mediator ->
+        mediator.addSource(rawReadings) { readings ->
+            mediator.value = toRateEntries(readings, chartMode.value ?: ChartMode.BY_DATE)
+        }
+        mediator.addSource(chartMode) { mode ->
+            mediator.value = toRateEntries(rawReadings.value.orEmpty(), mode)
+        }
+    }
+
     init {
         val db = TyreDatabase.getDatabase(application)
         repository = TyreRepository(db.tyrePressureDao(), db.tyreSettingsDao())
@@ -136,6 +157,57 @@ class ChartViewModel(application: Application) : AndroidViewModel(application) {
                 }
                 // MPAndroidChart requires entries sorted by x value
                 entries.sortBy { it.x }
+                entries
+            }
+        }
+    }
+
+    /**
+     * Compute deflation rate entries from consecutive readings.
+     *
+     * For each pair (prev → curr):
+     *   startPressure = prev.inflatedPressure ?: prev.measuredPressure
+     *   rate = (startPressure - curr.measuredPressure) / interval
+     *
+     * A positive rate means the tyre is losing pressure (normal).
+     * A higher rate than usual indicates a worsening leak.
+     */
+    private fun toRateEntries(
+        readings: List<TyrePressureReading>,
+        mode: ChartMode
+    ): List<Entry> {
+        if (readings.size < 2) return emptyList()
+
+        return when (mode) {
+            ChartMode.BY_DATE -> {
+                val entries = mutableListOf<Entry>()
+                for (i in 1 until readings.size) {
+                    val prev = readings[i - 1]
+                    val curr = readings[i]
+                    val startPressure = prev.inflatedPressure ?: prev.measuredPressure
+                    val daysBetween = (curr.timestamp - prev.timestamp) / (1000f * 60 * 60 * 24)
+                    if (daysBetween > 0) {
+                        val rate = (startPressure - curr.measuredPressure) / daysBetween
+                        entries.add(Entry(i.toFloat(), rate))
+                    }
+                }
+                entries
+            }
+
+            ChartMode.BY_MILEAGE -> {
+                val filtered = readings.filter { it.mileage != null }
+                if (filtered.size < 2) return emptyList()
+                val entries = mutableListOf<Entry>()
+                for (i in 1 until filtered.size) {
+                    val prev = filtered[i - 1]
+                    val curr = filtered[i]
+                    val startPressure = prev.inflatedPressure ?: prev.measuredPressure
+                    val milesBetween = (curr.mileage!! - prev.mileage!!).toFloat()
+                    if (milesBetween > 0) {
+                        val rate = (startPressure - curr.measuredPressure) / milesBetween
+                        entries.add(Entry(curr.mileage.toFloat(), rate))
+                    }
+                }
                 entries
             }
         }

--- a/app/src/main/java/com/example/tyrepressure/ui/settings/SettingsFragment.kt
+++ b/app/src/main/java/com/example/tyrepressure/ui/settings/SettingsFragment.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.example.tyrepressure.BuildConfig
 import com.example.tyrepressure.data.TyrePosition
 import com.example.tyrepressure.databinding.FragmentSettingsBinding
 
@@ -65,7 +64,14 @@ class SettingsFragment : Fragment() {
             if (isDone) findNavController().popBackStack()
         }
 
-        binding.textVersion.text = "Version ${BuildConfig.VERSION_NAME} (${BuildConfig.GIT_HASH})"
+        val gitHash = try {
+            requireContext().assets.open("git_hash.txt").bufferedReader().readText().trim()
+        } catch (e: Exception) {
+            "unknown"
+        }
+        val versionName = requireContext().packageManager
+            .getPackageInfo(requireContext().packageName, 0).versionName
+        binding.textVersion.text = "Version $versionName ($gitHash)"
 
         binding.buttonSaveSettings.setOnClickListener {
             saveSettings()


### PR DESCRIPTION
Closes #1

## Summary

- Adds a secondary dashed orange line to the deflation chart showing rate of pressure loss (PSI/day in By Date mode, PSI/mile in By Mileage mode)
- Rate is plotted on the right Y-axis so it doesn't interfere with the pressure scale on the left
- Uses inflated pressure as the start of each interval when available, reflecting true decline since last top-up
- Line only appears when there are at least 2 readings (rate is undefined with a single reading)
- Chart legend enabled to identify the two lines

## Test plan

- [ ] Record at least 2 readings for a tyre, confirm dashed rate line appears
- [ ] Record a reading with inflated pressure, confirm rate uses inflated value as interval start
- [ ] Switch between By Date and By Mileage — confirm rate label updates (PSI/day vs PSI/mile)
- [ ] Tyre with only 1 reading — confirm rate line is absent and no crash
- [ ] Tyre with no readings — confirm "no data" message still shows

🤖 Generated with [Claude Code](https://claude.com/claude-code)